### PR TITLE
fix permissions for /xyz

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -24,7 +24,6 @@ permissions:
      pmessentials.nick.self:
       default: op
       description: "change your nickname"
-      pmessentials.heal:
      pmessentials.nick.other:
       default: op
       description: "change someone else's nickname"
@@ -142,14 +141,14 @@ permissions:
       default: op
       description: "change someone else's movement speed"
    pmessentials.xyz:
-    default: true
+    default: op
     description: "shows coordinates"
     children:
      pmessentials.xyz.world:
       default: op
       description: "shows the world you're in"
      pmessentials.xyz.self:
-      default: op
+      default: true
       description: "shows your coordinates"
      pmessentials.xyz.other:
       default: op


### PR DESCRIPTION
And a fix for the mis-placed /heal permission randomly appearing in plugin.yml
I wasn't sure if this was meant to be in the plugin.yml or not, I'd assume it wasn't meant to be there, so I just did some fix-ups for the plugin.yml.
* Fixed /xyz bug, where people would be able to use /xyz such as: showing other coordinates (even though the permission node to check other coordinates wasn't set for that specific rank.
* Fixed a mis-place used permission for /heal
These changes have been tested to work (Tested on my server). Please merge if possible. Thank you!